### PR TITLE
Fix fatal error in ClassicPress by returning early if class does not exist

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -73,6 +73,10 @@ function i18n() {
  * @return void
  */
 function remove_comments_blocks() {
+	if(!class_exists('\WP_Block_Type_Registry')){
+		return;
+	}
+
 	$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 
 	$comment_blocks = [


### PR DESCRIPTION
Add a check for the presence of `WP_Block_Type_Registry` before attempting to use it,  to make this plugin compatible with ClassicPress. (Otherwise, it triggers a fatal error upon activation.) 